### PR TITLE
Creation of the structure to allow modifying how yaml will be written…

### DIFF
--- a/Swashbuckle.AspNetCore.Yaml.Example/Startup.cs
+++ b/Swashbuckle.AspNetCore.Yaml.Example/Startup.cs
@@ -44,6 +44,14 @@ namespace Swashbuckle.AspNetCore.Yaml.Example
                     }
                 });
 
+                c.AddSecurityDefinition("Bearer", new ApiKeyScheme
+                {
+                    In = "header",
+                    Description = "Please, put your token here.",
+                    Name = "Authorization",
+                    Type = "apiKey"
+                });
+
                 // Set the comments path for the Swagger JSON and UI.
                 var xmlFile = $"{Assembly.GetEntryAssembly().GetName().Name}.xml";
                 var xmlPath = Path.Combine(AppContext.BaseDirectory, xmlFile);

--- a/Swashbuckle.AspNetCore.Yaml.Example/Swashbuckle.AspNetCore.Yaml.Example.csproj
+++ b/Swashbuckle.AspNetCore.Yaml.Example/Swashbuckle.AspNetCore.Yaml.Example.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
@@ -7,10 +7,6 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DocumentationFile>bin\Debug\netcoreapp2.0\Swashbuckle.AspNetCore.Yaml.Example.xml</DocumentationFile>
   </PropertyGroup>
-
-  <ItemGroup>
-    <Folder Include="wwwroot\" />
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.6" />

--- a/Swashbuckle.AspNetCore.Yaml/Application/NamingConvention.cs
+++ b/Swashbuckle.AspNetCore.Yaml/Application/NamingConvention.cs
@@ -1,0 +1,40 @@
+﻿using YamlDotNet.Serialization.NamingConventions;
+
+namespace Swashbuckle.AspNetCore.Yaml.Application
+{
+    /// <summary>
+    /// Kind of string naming transformation
+    /// </summary>
+    public enum NamingConvention
+    {
+        /// <summary>
+        /// Performs no naming conversion.
+        /// </summary>
+        /// <seealso cref="NullNamingConvention"/>
+        Null,
+
+        /// <summary>
+        /// Convert the string with underscores or hyphens to camel case.
+        /// </summary>
+        /// <seealso cref="CamelCaseNamingConvention"/>
+        CamelCase,
+
+        /// <summary>
+        /// Convert the string with underscores.
+        /// </summary>
+        /// <seealso cref="HyphenatedNamingConvention"/>
+        Hyphenated,
+
+        /// <summary>
+        /// Convert the string with underscores or hyphens to pascal case.
+        /// </summary>
+        /// <seealso cref="PascalCaseNamingConvention"/>
+        PascalCase,
+
+        /// <summary>
+        /// Convert the string from camelcase to a underscored.
+        /// </summary>
+        /// <seealso cref="UnderscoredNamingConvention"/>
+        Underscored
+    }
+}

--- a/Swashbuckle.AspNetCore.Yaml/Application/SwaggerYamlOptions.cs
+++ b/Swashbuckle.AspNetCore.Yaml/Application/SwaggerYamlOptions.cs
@@ -1,9 +1,13 @@
-﻿namespace Swashbuckle.AspNetCore.Swagger.Yaml
+﻿using Swashbuckle.AspNetCore.Yaml.Application;
+
+namespace Swashbuckle.AspNetCore.Swagger.Yaml
 {
     public class SwaggerYamlOptions
     {
         public SwaggerOptions SwaggerOptions { get; set; } = new SwaggerOptions {  RouteTemplate = "swagger/{documentName}/swagger.yaml" };
 
         public string[] IgnoredProperties { get; set; } = {"extensions", "operation-id"};
+
+        public NamingConvention NamingConvention { get; set; }
     }
 }

--- a/Swashbuckle.AspNetCore.Yaml/Application/SwaggerYamlSerializerFactory.cs
+++ b/Swashbuckle.AspNetCore.Yaml/Application/SwaggerYamlSerializerFactory.cs
@@ -9,10 +9,30 @@ namespace Swashbuckle.AspNetCore.Swagger.Yaml
         public static Serializer Create(SwaggerYamlOptions swaggerYamlOptions)
         {
             var builder = new SerializerBuilder();
-            builder.WithNamingConvention(new HyphenatedNamingConvention());
+
+            switch (swaggerYamlOptions.NamingConvention)
+            {
+                case NamingConvention.CamelCase:
+                    builder.WithNamingConvention(new CamelCaseNamingConvention());
+                    break;
+
+                case NamingConvention.Hyphenated:
+                    builder.WithNamingConvention(new HyphenatedNamingConvention());
+                    break;
+
+                case NamingConvention.PascalCase:
+                    builder.WithNamingConvention(new PascalCaseNamingConvention());
+                    break;
+
+                case NamingConvention.Underscored:
+                    builder.WithNamingConvention(new UnderscoredNamingConvention());
+                    break;
+            }
+
             builder.WithTypeInspector(innerInspector => new PropertiesIgnoreTypeInspector(innerInspector, swaggerYamlOptions.IgnoredProperties));
             builder.WithTypeInspector(innerInspector => new JsonPropertyNameApplyingTypeInspector(innerInspector));
             builder.WithTypeInspector(innerInspector => new StringQuotingTypeInspector(innerInspector));
+
             return builder.Build();
         }
     }

--- a/Swashbuckle.AspNetCore.Yaml/Swashbuckle.AspNetCore.Yaml.csproj
+++ b/Swashbuckle.AspNetCore.Yaml/Swashbuckle.AspNetCore.Yaml.csproj
@@ -1,19 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.6" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="2.4.0" />
     <PackageReference Include="YamlDotNet" Version="4.3.1" />
   </ItemGroup>
-
-  <ItemGroup>
-    <Reference Include="YamlDotNet">
-      <HintPath>C:\Users\pawel_000\.nuget\packages\yamldotnet\4.3.1\lib\netstandard1.3\YamlDotNet.dll</HintPath>
-    </Reference>
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
…. Adjustment in references.

The following modifications were made:

- The project has been changed to not have Microsoft.AspNetCore.All why this reference is implied in .net core 2.0+.
- Options have been added to modify how reserved swagger keys are written.
- In the SwaggerYamlSerializerFactory factory, it has been modified to use NamingConvention.